### PR TITLE
Edit spelling of GitHub

### DIFF
--- a/src/_includes/footer.html
+++ b/src/_includes/footer.html
@@ -18,7 +18,7 @@
             </svg>
           </div>
           <div class="button-label">
-            Github
+            GitHub
           </div>
         </div>
       </a>

--- a/src/_includes/header.html
+++ b/src/_includes/header.html
@@ -14,7 +14,7 @@
             </svg>
           </div>
           <div class="button-label">
-            Github
+            GitHub
           </div>
         </div>
       </a>

--- a/src/index.html
+++ b/src/index.html
@@ -48,7 +48,7 @@ regenerate: true
               </svg>
             </div>
             <div class="button-text">
-              Github
+              GitHub
             </div>
           </div>
         </a>


### PR DESCRIPTION
Corrects a very common error when referring to GitHub. The middle 'H' should be in caps.