### PR TITLE
Deploy: Fix repo URL

### DIFF
--- a/deploy.js
+++ b/deploy.js
@@ -3,7 +3,7 @@ var path = require('path');
 
 ghpages.publish(path.join(__dirname, 'dist'), {
   branch: 'master',
-  repo: 'https://${GH_TOKEN}@github.com/nteract/nteract.github.io.git',
+  repo: 'https://' + process.env.GH_TOKEN + '@github.com/nteract/nteract.github.io.git',
   silent: true,
   user: {
     name: 'Travis Bot',


### PR DESCRIPTION
Silly me. We aren't working with the command line interface here.

This should work now. 🚀 