### PR TITLE
Force the footer image width to be 100%.

### DIFF
--- a/src/assets/scss/layout/layout.footer.scss
+++ b/src/assets/scss/layout/layout.footer.scss
@@ -33,7 +33,7 @@
       li {
         max-width: 150px;
         img {
-          max-width: 100%;
+          width: 100%;
         }
         padding: $unit*2;
       }


### PR DESCRIPTION
This fixes an IE11 bug. Fixes #33.