### PR TITLE
fix(mobileHeader): optimize header for mobile

### DIFF
--- a/src/assets/scss/elements/element.buttons.scss
+++ b/src/assets/scss/elements/element.buttons.scss
@@ -3,7 +3,7 @@
 
   @include handheld {
     &.mobile-only {
-      width: 100%;
+      width: 75%;
       margin: $unit*2 0;
       margin-left:0 !important;
       padding: 0;

--- a/src/assets/scss/layout/layout.section.scss
+++ b/src/assets/scss/layout/layout.section.scss
@@ -148,6 +148,7 @@ section {
         }
         @include tablet {
           padding: 0 $unit*4;
+          max-width: 100%;
         }
         @include tablet {
         }


### PR DESCRIPTION
While showing my wife the beautiful design of this site (seriously, this is absolutely one of the best designed sites I have ever seen -- kudos to all :tada:), she noticed that the header text wasn't wrapping properly as the sections do. 

## Current
![screen shot 2017-03-04 at 2 34 38 pm](https://cloud.githubusercontent.com/assets/15242567/23581749/98003178-00e8-11e7-847b-c4ab3362acb6.png)
This should address that styling.

## After
![screen shot 2017-03-04 at 2 34 54 pm](https://cloud.githubusercontent.com/assets/15242567/23581751/af9fb358-00e8-11e7-939a-6a2d7fe5dc40.png)


